### PR TITLE
Fix party commands

### DIFF
--- a/features/General(Move).js
+++ b/features/General(Move).js
@@ -136,7 +136,7 @@ registerWhen(register("chat", (player, command) => {
         ChatLib.command(`pc https://i.imgur.com/tsg6tx5.jpg`); break;
       case "ver":
       case "version":
-        ChatLib.command(`pc ${version}`)
+        ChatLib.command(`pc ${version}`); break;
       case "t5":
       case "raider":
         CommandMsg = `joininstance kuudra_infernal`; break;
@@ -160,7 +160,7 @@ registerWhen(register("chat", (player, command) => {
       ChatLib.command(CommandMsg);
     }
   }, 300)
-}).setCriteria(/Party > (.+): [.?!](.+)/), () => settings.party)
+}).setCriteria(/Party > ([^:]+): [,.?!](.+)/), () => settings.party)
 
 let reaperUsed = 0
 registerWhen(register("soundPlay", () => {


### PR DESCRIPTION
- Fixed party command regex (https://regex101.com/r/8iYAHO/1)
	It now takes everything before the first colon.
	before fix: 
![image](https://github.com/user-attachments/assets/dd9ad07b-9e07-41d3-b153-61d7ab850eaf)
	after fix:
![image](https://github.com/user-attachments/assets/b367c38a-8d6f-40f8-8f4f-6aebea19a7f6)

- Added a missing `break`